### PR TITLE
Override the trailing comma rule in the airbnb eslint config.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,6 @@
 module.exports = {
-    "extends": "airbnb"
+  "extends": "airbnb",
+  "rules": {
+    "comma-dangle": ["error", "never"]
+  }
 };

--- a/server/config/auth/passportConfig.js
+++ b/server/config/auth/passportConfig.js
@@ -28,5 +28,5 @@ passport.use(strategy);
 
 export default {
   passport,
-  jwtOptions,
+  jwtOptions
 };

--- a/server/db/controllers/users.js
+++ b/server/db/controllers/users.js
@@ -7,13 +7,13 @@ export default {
       last_name: params.last_name,
       password_hash: params.password,
       phone_number: params.phone_number,
-      email: params.email,
+      email: params.email
     })
       .save(),
 
   getUserByEmail: params =>
     new User({
-      email: params,
+      email: params.email
     })
       .fetch(),
 
@@ -28,17 +28,17 @@ export default {
         last_name: params.last_name,
         password_hash: params.password,
         phone_number: params.phone_number,
-        email: params.email,
+        email: params.email
       }, {
-        method: 'update',
+        method: 'update'
       }),
 
   deactivateUserById: params =>
     new User()
       .where({ id: params.id })
       .save({
-        is_active: false,
+        is_active: false
       }, {
-        method: 'update',
-      }),
+        method: 'update'
+      })
 };

--- a/server/db/init.js
+++ b/server/db/init.js
@@ -4,7 +4,7 @@ import bookshelfModule from 'bookshelf';
 const knex = knexModule({
   client: 'pg',
   connection: process.env.PG_CONNECTION_STRING,
-  debug: true,
+  debug: true
 });
 
 const bookshelf = bookshelfModule(knex);

--- a/server/db/models/users.js
+++ b/server/db/models/users.js
@@ -6,7 +6,7 @@ bookshelf.plugin(bookshelfBcrypt);
 const User = bookshelf.Model.extend({
   tableName: 'users',
   bcrypt: { field: 'password_hash' },
-  hasTimestamps: false,
+  hasTimestamps: false
 });
 
 export default User;

--- a/server/routes/authenticate.js
+++ b/server/routes/authenticate.js
@@ -22,7 +22,7 @@ router.post('/', (req, res) => {
           const token = genToken(user.id);
           res.json({
             message: 'login successful',
-            token,
+            token
           });
         } else {
           console.log('password no match');


### PR DESCRIPTION
This modifies .eslintrc to override the airbnb configuration (which
prefers to use trailing commas) so that trailing commas are now an error
on the linter.
You can read more about this rule here:
http://eslint.org/docs/rules/comma-dangle