### PR TITLE
Make server Export/Import only needed modules to/from  passportConfig.js

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -10,18 +10,12 @@ import users from './routes/users';
 import authenticate from './routes/authenticate';
 import register from './routes/register';
 
-import passportModule from './config/auth/passportConfig';
+import { passport } from './config/auth/passportConfig';
 
 const app = express();
 
-const passport = passportModule.passport;
-
 app.use(passport.initialize());
 
-// initializing env variables
-
-
-// view engine setup
 // uncomment after placing your favicon in /public
 // app.use(favicon(path.join(__dirname, 'public', 'favicon.ico')));
 app.use(logger('dev'));

--- a/server/config/auth/jwtGenerator.js
+++ b/server/config/auth/jwtGenerator.js
@@ -1,9 +1,9 @@
 import jwt from 'jsonwebtoken';
-import passportConfig from './passportConfig';
+import { jwtOptions } from './passportConfig';
 
 export default function genToken(userId) {
   const payload = { id: userId };
-  const token = jwt.sign(payload, passportConfig.jwtOptions.secretOrKey);
+  const token = jwt.sign(payload, jwtOptions.secretOrKey);
 
   return token;
 }

--- a/server/config/auth/passportConfig.js
+++ b/server/config/auth/passportConfig.js
@@ -26,7 +26,5 @@ const strategy = new JwtStrategy(jwtOptions, (jwtPayload, next) => {
 
 passport.use(strategy);
 
-export default {
-  passport,
-  jwtOptions
-};
+export { passport };
+export { jwtOptions };


### PR DESCRIPTION
Previously, passportConfig.js exported a single object containing
multiple objects as the default export and files imported the entire
exported object and then called the objects they needed from it.

Now, passportConfig.js exports each individual object in its own named
export and modules only import what they need and no more.