### PR TITLE
Add redux-persist module for store persistence

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "redux-form": "^7.0.1",
     "redux-immutable-state-invariant": "^2.0.0",
     "redux-logger": "^3.0.6",
+    "redux-persist": "^4.8.3",
     "redux-promise": "^0.5.3",
     "redux-promise-middleware": "^4.3.0",
     "redux-thunk": "^2.2.0",

--- a/public/src/store.jsx
+++ b/public/src/store.jsx
@@ -1,4 +1,5 @@
 import { applyMiddleware, createStore, combineReducers, compose } from 'redux';
+import { persistStore, autoRehydrate } from 'redux-persist';
 import { reducer as formReducer } from 'redux-form';
 
 import thunk from 'redux-thunk';
@@ -25,6 +26,8 @@ const rootReducer = (state, action) => {
 
 const middleware = [immutable(), createLogger(), promise(), thunk];
 
-const store = createStore(rootReducer, compose(applyMiddleware(...middleware)));
+const store = createStore(rootReducer, compose(applyMiddleware(...middleware), autoRehydrate()));
+
+persistStore(store);
 
 export default store;


### PR DESCRIPTION
Store.jsx now imports and uses the redux-persist module to make sessions
persist across window and tab closures.