### PR TITLE
Modify /campaigns Endpoint to Use Status Param

### DIFF
--- a/server/config/routes/campaigns.js
+++ b/server/config/routes/campaigns.js
@@ -7,6 +7,6 @@ const router = express.Router();
 router.use(passport.authenticate('jwt', { session: false }));
 
 router.route('/').post(saveNewCampaign);
-router.route('/:status').get(getAllCampaigns);
+router.route('/').get(getAllCampaigns);
 
 export default router;

--- a/server/config/routes/campaigns.js
+++ b/server/config/routes/campaigns.js
@@ -7,6 +7,6 @@ const router = express.Router();
 router.use(passport.authenticate('jwt', { session: false }));
 
 router.route('/').post(saveNewCampaign);
-router.route('/').get(getAllCampaigns);
+router.route('/:status').get(getAllCampaigns);
 
 export default router;

--- a/server/controllers/campaigns.js
+++ b/server/controllers/campaigns.js
@@ -26,8 +26,6 @@ export function saveNewCampaign(req, res) {
 
 export function getAllCampaigns(req, res) {
   const status = req.params.status === undefined ? 'all' : req.params.status;
-  console.log('status is: ', status);
-  console.log('req.params.status is: ', req.params.status);
   return campaignsService.getAllCampaigns(status)
     .then((campaigns) => {
       res.status(200).send(campaigns);

--- a/server/controllers/campaigns.js
+++ b/server/controllers/campaigns.js
@@ -25,7 +25,9 @@ export function saveNewCampaign(req, res) {
 }
 
 export function getAllCampaigns(req, res) {
-  const status = req.params.status === undefined ? 'all' : req.params.status;
+  const reqStatus = req.query.status;
+  const statuses = ['active', 'completed', 'draft', 'pause'];
+  const status = statuses.includes(reqStatus) ? reqStatus : 'all';
   return campaignsService.getAllCampaigns(status)
     .then((campaigns) => {
       res.status(200).send(campaigns);

--- a/server/controllers/campaigns.js
+++ b/server/controllers/campaigns.js
@@ -25,13 +25,15 @@ export function saveNewCampaign(req, res) {
 }
 
 export function getAllCampaigns(req, res) {
-  return campaignsService.getAllCampaigns(null)
+  console.log('req.body for getAllCampaigns is: ', req.body);
+  const { params } = req.body;
+  return campaignsService.getAllCampaigns(campaign_status)
     .then((campaigns) => {
       res.status(200).send(campaigns);
     })
     .catch((err) => {
       res.status(500).json({
-        message: 'Cannot retrieve campaigns',
+        message: `Cannot retrieve campaigns with status: ${campaign_status}`,
         error: err
       });
     });

--- a/server/controllers/campaigns.js
+++ b/server/controllers/campaigns.js
@@ -25,15 +25,16 @@ export function saveNewCampaign(req, res) {
 }
 
 export function getAllCampaigns(req, res) {
-  console.log('req.body for getAllCampaigns is: ', req.body);
-  const { params } = req.body;
-  return campaignsService.getAllCampaigns(campaign_status)
+  const status = req.params.status === undefined ? 'all' : req.params.status;
+  console.log('status is: ', status);
+  console.log('req.params.status is: ', req.params.status);
+  return campaignsService.getAllCampaigns(status)
     .then((campaigns) => {
       res.status(200).send(campaigns);
     })
     .catch((err) => {
       res.status(500).json({
-        message: `Cannot retrieve campaigns with status: ${campaign_status}`,
+        message: `Cannot retrieve campaigns with status: ${status}`,
         error: err
       });
     });

--- a/server/db/services/campaigns.js
+++ b/server/db/services/campaigns.js
@@ -7,5 +7,16 @@ export default {
     return new Campaign({ name, title, description, status, script_id, contact_lists_id }).save();
   },
 
-  getAllCampaigns: () => new Campaign().fetchAll()
+  getAllCampaigns: (campaign_status = 'all') => {
+    if (campaign_status === 'all') {
+      new Campaign()
+        .orderBy('id', 'DESC')
+        .fetchAll();
+    } else {
+      new Campaign()
+        .where({ campaign_status })
+        .orderBy('id', 'DESC')
+        .fetchAll();
+    }
+  }
 };

--- a/server/db/services/campaigns.js
+++ b/server/db/services/campaigns.js
@@ -7,16 +7,15 @@ export default {
     return new Campaign({ name, title, description, status, script_id, contact_lists_id }).save();
   },
 
-  getAllCampaigns: (campaign_status = 'all') => {
-    if (campaign_status === 'all') {
-      new Campaign()
-        .orderBy('id', 'DESC')
-        .fetchAll();
-    } else {
-      new Campaign()
-        .where({ campaign_status })
+  getAllCampaigns: (status) => {
+    if (status === 'all') {
+      return new Campaign()
         .orderBy('id', 'DESC')
         .fetchAll();
     }
+    return new Campaign()
+      .where({ status })
+      .orderBy('id', 'DESC')
+      .fetchAll();
   }
 };

--- a/test/server/services/campaigns.js
+++ b/test/server/services/campaigns.js
@@ -70,22 +70,53 @@ describe('Campaign service tests', () => {
     });
 
     it('should get all campaigns', (done) => {
-      campaignsService.getAllCampaigns(null)
+      const status = 'all';
+      campaignsService.getAllCampaigns(status)
         .then((campaigns) => {
           const { models } = campaigns;
           expect(models).to.have.length(2);
+          expect(models[1].attributes.name).to.equal(this.campaignParams1.name);
+          expect(models[1].attributes.title).to.equal(this.campaignParams1.title);
+          expect(models[1].attributes.description).to.equal(this.campaignParams1.description);
+          expect(models[1].attributes.status).to.equal(this.campaignParams1.status);
+          expect(models[1].attributes.script_id).to.equal(this.campaignParams1.script_id);
+          expect(models[1].attributes.script_id).to.equal(this.campaignParams1.contact_lists_id);
+          expect(models[0].attributes.name).to.equal(this.campaignParams2.name);
+          expect(models[0].attributes.title).to.equal(this.campaignParams2.title);
+          expect(models[0].attributes.description).to.equal(this.campaignParams2.description);
+          expect(models[0].attributes.status).to.equal(this.campaignParams2.status);
+          expect(models[0].attributes.script_id).to.equal(this.campaignParams2.script_id);
+          expect(models[0].attributes.script_id).to.equal(this.campaignParams2.contact_lists_id);
+          done();
+        });
+    });
+    it('should get all draft campaigns', (done) => {
+      const status = 'draft';
+      campaignsService.getAllCampaigns(status)
+        .then((campaigns) => {
+          const { models } = campaigns;
+          expect(models).to.have.length(1);
           expect(models[0].attributes.name).to.equal(this.campaignParams1.name);
           expect(models[0].attributes.title).to.equal(this.campaignParams1.title);
           expect(models[0].attributes.description).to.equal(this.campaignParams1.description);
           expect(models[0].attributes.status).to.equal(this.campaignParams1.status);
           expect(models[0].attributes.script_id).to.equal(this.campaignParams1.script_id);
           expect(models[0].attributes.script_id).to.equal(this.campaignParams1.contact_lists_id);
-          expect(models[1].attributes.name).to.equal(this.campaignParams2.name);
-          expect(models[1].attributes.title).to.equal(this.campaignParams2.title);
-          expect(models[1].attributes.description).to.equal(this.campaignParams2.description);
-          expect(models[1].attributes.status).to.equal(this.campaignParams2.status);
-          expect(models[1].attributes.script_id).to.equal(this.campaignParams2.script_id);
-          expect(models[1].attributes.script_id).to.equal(this.campaignParams2.contact_lists_id);
+          done();
+        });
+    });
+    it('should get all active campaigns', (done) => {
+      const status = 'active';
+      campaignsService.getAllCampaigns(status)
+        .then((campaigns) => {
+          const { models } = campaigns;
+          expect(models).to.have.length(1);
+          expect(models[0].attributes.name).to.equal(this.campaignParams2.name);
+          expect(models[0].attributes.title).to.equal(this.campaignParams2.title);
+          expect(models[0].attributes.description).to.equal(this.campaignParams2.description);
+          expect(models[0].attributes.status).to.equal(this.campaignParams2.status);
+          expect(models[0].attributes.script_id).to.equal(this.campaignParams2.script_id);
+          expect(models[0].attributes.script_id).to.equal(this.campaignParams2.contact_lists_id);
           done();
         });
     });


### PR DESCRIPTION
**Description:**

- Update getAllCampaigns service to accept a status param and query accordingly
- Update getAllCampaigns controller to get the status param and call getAllCampaigns service with the param
- Add tests for getAllCampaigns service