### PR TITLE
BUG FIX: Update description field in script_list view

### DIFF
--- a/public/src/components/common/list_table_headers.js
+++ b/public/src/components/common/list_table_headers.js
@@ -4,7 +4,7 @@ const tableInfo = {
     redirect_path: '/admin/campaigns/new'
   },
   scripts: {
-    headers: [['Name', 'name'], ['Body', 'body'], ['Description', 'created_at'], ['Created At', 'created_at'], ['Updated At', 'updated_at']],
+    headers: [['Name', 'name'], ['Body', 'body'], ['Description', 'description'], ['Created At', 'created_at'], ['Updated At', 'updated_at']],
     redirect_path: '/admin/scripts/new'
   },
   questions: {


### PR DESCRIPTION
Description:
- Update description field in admin script list view to display the description (was displaying the created_at datetime)

Test:
- Login as an admin
- Navigate to the all scripts tab
- See the description displayed properly