### PR TITLE
Update Volunteer Calls Endpoint

### DIFF
--- a/public/src/actions/calls.jsx
+++ b/public/src/actions/calls.jsx
@@ -47,11 +47,13 @@ export function clearCurrentCall() {
   };
 }
 
-export function assignToCall(userId, campaignId, currentCall) {
-  return dispatch => axios.get(`/users/${userId}/campaigns/${campaignId}/calls`)
+export function assignToCall(userId, campaignId) {
+  return dispatch => axios.get(`/users/${userId}/campaigns/${campaignId}/calls`, {
+    headers: { Authorization: ` JWT ${localStorage.getItem('auth_token')}` }
+  })
     .then((call) => {
       const { data: callObj } = call;
-      return !currentCall ? dispatch(setCurrentCall(callObj)) : dispatch(setNextCall(callObj));
+      dispatch(setCurrentCall(callObj));
     })
     .catch(err => console.log(err));
 }

--- a/public/src/actions/calls.jsx
+++ b/public/src/actions/calls.jsx
@@ -48,7 +48,7 @@ export function clearCurrentCall() {
 }
 
 export function assignToCall(userId, campaignId, currentCall) {
-  return dispatch => axios.post(`/users/${userId}/campaigns/${campaignId}/calls`)
+  return dispatch => axios.get(`/users/${userId}/campaigns/${campaignId}/calls`)
     .then((call) => {
       const { data: callObj } = call;
       return !currentCall ? dispatch(setCurrentCall(callObj)) : dispatch(setNextCall(callObj));

--- a/public/src/reducers/calls.jsx
+++ b/public/src/reducers/calls.jsx
@@ -1,4 +1,4 @@
-const defaultCalls = {
+export const defaultCalls = {
   current_call: undefined,
   next_call: undefined,
   calls_made: 0

--- a/server/config/routes/users.js
+++ b/server/config/routes/users.js
@@ -8,8 +8,8 @@ import { addCampaignToUser,
          manageUserById,
          updateUserById,
          getUserCampaignAssociation,
-         updateUserCallSidField,
-         clearUserCallSidField } from '../../controllers/users';
+         updateUserCallSIDField,
+         clearUserCallSIDField } from '../../controllers/users';
 
 import { assignCall } from '../../controllers/calls';
 
@@ -27,7 +27,7 @@ router.route('/:id/campaigns').post(addCampaignToUser);
 router.route('/:id/campaigns').get(getUserCampaigns);
 router.route('/:id/campaigns/:campaign_id').get(getUserCampaignAssociation);
 router.route('/:id/campaigns/:campaign_id/calls').get(assignCall);
-router.route('/:id/campaigns/:campaign_id/calls').post(updateUserCallSidField);
-router.route('/:id/campaigns/:campaign_id/calls').delete(clearUserCallSidField);
+router.route('/:id/campaigns/:campaign_id/calls').post(updateUserCallSIDField);
+router.route('/:id/campaigns/:campaign_id/calls').delete(clearUserCallSIDField);
 
 export default router;

--- a/server/config/routes/users.js
+++ b/server/config/routes/users.js
@@ -1,5 +1,5 @@
 import express from 'express';
-// import { passport } from '../auth/local';
+import { passport } from '../auth/local';
 import { addCampaignToUser,
          getAllUsers,
          getUserById,
@@ -16,7 +16,7 @@ import { assignCall } from '../../controllers/calls';
 
 const router = express.Router();
 
-// router.use(passport.authenticate('jwt', { session: false }));
+router.use(passport.authenticate('jwt', { session: false }));
 
 router.route('/').get(getAllUsers);
 router.route('/:id').get(getUserById);

--- a/server/config/routes/users.js
+++ b/server/config/routes/users.js
@@ -1,5 +1,5 @@
 import express from 'express';
-import { passport } from '../auth/local';
+// import { passport } from '../auth/local';
 import { addCampaignToUser,
          getAllUsers,
          getUserById,
@@ -7,14 +7,16 @@ import { addCampaignToUser,
          deactivateUserById,
          manageUserById,
          updateUserById,
-         getUserCampaignAssociation } from '../../controllers/users';
+         getUserCampaignAssociation,
+         updateUserCallSidField,
+         clearUserCallSidField } from '../../controllers/users';
 
 import { assignCall } from '../../controllers/calls';
 
 
 const router = express.Router();
 
-router.use(passport.authenticate('jwt', { session: false }));
+// router.use(passport.authenticate('jwt', { session: false }));
 
 router.route('/').get(getAllUsers);
 router.route('/:id').get(getUserById);
@@ -24,6 +26,8 @@ router.route('/:id/manage').put(manageUserById);
 router.route('/:id/campaigns').post(addCampaignToUser);
 router.route('/:id/campaigns').get(getUserCampaigns);
 router.route('/:id/campaigns/:campaign_id').get(getUserCampaignAssociation);
-router.route('/:id/campaigns/:campaign_id/calls').post(assignCall);
+router.route('/:id/campaigns/:campaign_id/calls').get(assignCall);
+router.route('/:id/campaigns/:campaign_id/calls').post(updateUserCallSidField);
+router.route('/:id/campaigns/:campaign_id/calls').delete(clearUserCallSidField);
 
 export default router;

--- a/server/controllers/users.js
+++ b/server/controllers/users.js
@@ -187,3 +187,39 @@ export function getUserCampaignAssociation(req, res) {
       res.status(404).json({ message: `Cannot process request for campaign_user association: ${err}` });
     });
 }
+
+export function updateUserCallSidField(req, res, next) {
+  const { id } = req.params;
+  const call_sid = 'CAdksl234591adfide294821kdau3u3933';
+  const params = { id, call_sid };
+  return usersService.updateUserById(params)
+    .then((user) => {
+      if (user) {
+        res.status(200).json(user);
+      } else {
+        next();
+      }
+    })
+    .catch((err) => {
+      res.status(404).json({ message: `Could process request to update user Call SID: ${err}` });
+    });
+}
+
+export function clearUserCallSidField(req, res, next) {
+  const { id } = req.params;
+  const params = {
+    id,
+    call_sid: null
+  };
+  return usersService.updateUserById(params)
+    .then((user) => {
+      if (user) {
+        res.status(200).json(user);
+      } else {
+        next();
+      }
+    })
+    .catch((err) => {
+      res.status(404).json({ message: `Could not process request to clear user Call SID: ${err}` });
+    });
+}

--- a/server/controllers/users.js
+++ b/server/controllers/users.js
@@ -188,7 +188,7 @@ export function getUserCampaignAssociation(req, res) {
     });
 }
 
-export function updateUserCallSidField(req, res, next) {
+export function updateUserCallSIDField(req, res, next) {
   const { id } = req.params;
   const call_sid = 'CAdksl234591adfide294821kdau3u3933';
   const params = { id, call_sid };
@@ -201,11 +201,11 @@ export function updateUserCallSidField(req, res, next) {
       }
     })
     .catch((err) => {
-      res.status(404).json({ message: `Could process request to update user Call SID: ${err}` });
+      res.status(404).json({ message: `Could not process request to update user Call SID: ${err}` });
     });
 }
 
-export function clearUserCallSidField(req, res, next) {
+export function clearUserCallSIDField(req, res, next) {
   const { id } = req.params;
   const params = {
     id,

--- a/server/controllers/users.js
+++ b/server/controllers/users.js
@@ -188,7 +188,7 @@ export function getUserCampaignAssociation(req, res) {
     });
 }
 
-export function updateUserCallSIDField(req, res, next) {
+export function updateUserCallSIDField(req, res) {
   const { id } = req.params;
   const call_sid = 'CAdksl234591adfide294821kdau3u3933';
   const params = { id, call_sid };
@@ -197,15 +197,15 @@ export function updateUserCallSIDField(req, res, next) {
       if (user) {
         res.status(200).json(user);
       } else {
-        next();
+        res.status(404).json({ message: 'Could not process request to update user Call SID' });
       }
     })
     .catch((err) => {
-      res.status(404).json({ message: `Could not process request to update user Call SID: ${err}` });
+      res.status(500).json({ message: `Could not process request to update user Call SID: ${err}` });
     });
 }
 
-export function clearUserCallSIDField(req, res, next) {
+export function clearUserCallSIDField(req, res) {
   const { id } = req.params;
   const params = {
     id,
@@ -216,10 +216,10 @@ export function clearUserCallSIDField(req, res, next) {
       if (user) {
         res.status(200).json(user);
       } else {
-        next();
+        res.status(404).json({ message: 'Could not process request to clear user Call SID' });
       }
     })
     .catch((err) => {
-      res.status(404).json({ message: `Could not process request to clear user Call SID: ${err}` });
+      res.status(500).json({ message: `Could not process request to clear user Call SID: ${err}` });
     });
 }

--- a/server/db/db.js
+++ b/server/db/db.js
@@ -137,6 +137,7 @@ const createUsersTable = () =>
         table.boolean('is_admin').defaultTo(false);
         table.boolean('is_banned').defaultTo(false);
         table.boolean('is_active').defaultTo(true);
+        table.string('call_sid', 34);
         table.timestamp('created_at').defaultTo(bookshelf.knex.fn.now());
         table.timestamp('updated_at').defaultTo(bookshelf.knex.fn.now());
       });

--- a/server/db/services/users.js
+++ b/server/db/services/users.js
@@ -37,8 +37,8 @@ export default {
       email: params.email,
       is_admin: params.isAdmin,
       is_active: params.isActive,
-      is_banned: params.isBanned
-
+      is_banned: params.isBanned,
+      call_sid: params.call_sid
     };
     return new User()
       .where({ id })

--- a/test/client/actions/calls.test.js
+++ b/test/client/actions/calls.test.js
@@ -7,22 +7,22 @@ import fixtures from '../client_fixtures';
 
 let mocker;
 let store;
-const { call1, assignedCall1, currentCall2 } = fixtures.callsFixture;
+const { call, assignedCall, currentCall } = fixtures.callsFixture;
 
 describe('Call Actions', () => {
   describe('assignToCall Action', () => {
     store = mockStore(defaultCalls);
     mocker = new MockAdapter(axios);
     beforeEach(() => {
-      mocker.onGet('/users/1/campaigns/1/calls').reply(200, assignedCall1);
+      mocker.onGet('/users/1/campaigns/1/calls').reply(200, assignedCall);
     });
     afterEach(() => {
       mocker.reset();
     });
     it('should dispatch setCurrentCall action if a currentCall does not exist', () => {
       const userId = 1;
-      const { type, payload } = setCurrentCall(assignedCall1);
-      store.dispatch(assignToCall(userId, call1.campaign_id))
+      const { type, payload } = setCurrentCall(assignedCall);
+      store.dispatch(assignToCall(userId, call.campaign_id))
         .then(() => {
           const actions = store.getActions();
           expect(actions[0].type).toEqual(type);
@@ -34,8 +34,8 @@ describe('Call Actions', () => {
     });
     it('should dispatch setNextCall action if a currentCall exists', () => {
       const userId = 1;
-      const { type, payload } = setNextCall(assignedCall1);
-      store.dispatch(assignToCall(userId, call1.campaign_id, currentCall2))
+      const { type, payload } = setNextCall(assignedCall);
+      store.dispatch(assignToCall(userId, call.campaign_id, currentCall))
         .then(() => {
           const actions = store.getActions();
           expect(actions[1].type).toEqual(type);

--- a/test/client/actions/calls.test.js
+++ b/test/client/actions/calls.test.js
@@ -1,13 +1,12 @@
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
-import { mockStore, exposeLocalStorageMock } from '../client_test_helpers';
+import { mockStore } from '../client_test_helpers';
 import { setCurrentCall, setNextCall, assignToCall } from '../../../public/src/actions/calls';
 import { defaultCalls } from '../../../public/src/reducers/calls';
 import fixtures from '../client_fixtures';
 
 let mocker;
 let store;
-exposeLocalStorageMock();
 const { call1, assignedCall1, currentCall2 } = fixtures.callsFixture;
 
 describe('Call Actions', () => {

--- a/test/client/actions/calls.test.js
+++ b/test/client/actions/calls.test.js
@@ -1,0 +1,50 @@
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+import { mockStore, exposeLocalStorageMock } from '../client_test_helpers';
+import { setCurrentCall, setNextCall, assignToCall } from '../../../public/src/actions/calls';
+import { defaultCalls } from '../../../public/src/reducers/calls';
+import fixtures from '../client_fixtures';
+
+let mocker;
+let store;
+exposeLocalStorageMock();
+const { call1, assignedCall1, currentCall2 } = fixtures.callsFixture;
+
+describe('Call Actions', () => {
+  describe('assignToCall Action', () => {
+    store = mockStore(defaultCalls);
+    mocker = new MockAdapter(axios);
+    beforeEach(() => {
+      mocker.onGet('/users/1/campaigns/1/calls').reply(200, assignedCall1);
+    });
+    afterEach(() => {
+      mocker.reset();
+    });
+    it('should dispatch setCurrentCall action if a currentCall does not exist', () => {
+      const userId = 1;
+      const { type, payload } = setCurrentCall(assignedCall1);
+      store.dispatch(assignToCall(userId, call1.campaign_id))
+        .then(() => {
+          const actions = store.getActions();
+          expect(actions[0].type).toEqual(type);
+          expect(actions[0].payload).toEqual(payload);
+        })
+        .catch((err) => {
+          console.log(`Error in assignToCall action dispatch setCurrentCall is: ${err}`);
+        });
+    });
+    it('should dispatch setNextCall action if a currentCall exists', () => {
+      const userId = 1;
+      const { type, payload } = setNextCall(assignedCall1);
+      store.dispatch(assignToCall(userId, call1.campaign_id, currentCall2))
+        .then(() => {
+          const actions = store.getActions();
+          expect(actions[1].type).toEqual(type);
+          expect(actions[1].payload).toEqual(payload);
+        })
+        .catch((err) => {
+          console.log(`Error in assignToCall action dispatch setNextCall is: ${err}`);
+        });
+    });
+  });
+});

--- a/test/client/actions/calls.test.js
+++ b/test/client/actions/calls.test.js
@@ -8,7 +8,7 @@ import fixtures from '../client_fixtures';
 exposeLocalStorageMock();
 let mocker;
 let store;
-const { call, assignedCall, currentCall } = fixtures.callsFixture;
+const { call, assignedCall } = fixtures.callsFixture;
 
 describe('Call Actions', () => {
   describe('assignToCall Action', () => {

--- a/test/client/actions/calls.test.js
+++ b/test/client/actions/calls.test.js
@@ -19,7 +19,7 @@ describe('Call Actions', () => {
     afterEach(() => {
       mocker.reset();
     });
-    it('should dispatch setCurrentCall action if a currentCall does not exist', () => {
+    it('should dispatch setCurrentCall action', () => {
       const userId = 1;
       const { type, payload } = setCurrentCall(assignedCall);
       store.dispatch(assignToCall(userId, call.campaign_id))
@@ -30,19 +30,6 @@ describe('Call Actions', () => {
         })
         .catch((err) => {
           console.log(`Error in assignToCall action dispatch setCurrentCall is: ${err}`);
-        });
-    });
-    it('should dispatch setNextCall action if a currentCall exists', () => {
-      const userId = 1;
-      const { type, payload } = setNextCall(assignedCall);
-      store.dispatch(assignToCall(userId, call.campaign_id, currentCall))
-        .then(() => {
-          const actions = store.getActions();
-          expect(actions[1].type).toEqual(type);
-          expect(actions[1].payload).toEqual(payload);
-        })
-        .catch((err) => {
-          console.log(`Error in assignToCall action dispatch setNextCall is: ${err}`);
         });
     });
   });

--- a/test/client/actions/calls.test.js
+++ b/test/client/actions/calls.test.js
@@ -1,10 +1,11 @@
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
-import { mockStore } from '../client_test_helpers';
+import { mockStore, exposeLocalStorageMock } from '../client_test_helpers';
 import { setCurrentCall, setNextCall, assignToCall } from '../../../public/src/actions/calls';
 import { defaultCalls } from '../../../public/src/reducers/calls';
 import fixtures from '../client_fixtures';
 
+exposeLocalStorageMock();
 let mocker;
 let store;
 const { call, assignedCall, currentCall } = fixtures.callsFixture;

--- a/test/client/client_fixtures.js
+++ b/test/client/client_fixtures.js
@@ -354,5 +354,52 @@ export default {
       created_at: '2017-08-24T01:01:01.145Z',
       updated_at: '2017-08-25T22:01:10.202Z'
     }
+  },
+  callsFixture: {
+    call1: {
+      id: 1,
+      campaign_id: 1,
+      contact_id: 1,
+      attempt_num: 1,
+      user_id: null,
+      status: 'AVAILABLE',
+      outcome: 'PENDING',
+      notes: null,
+      call_sid: null,
+      call_started: null,
+      call_ended: null,
+      created_at: '2017-08-15T21:35:30.321Z',
+      updated_at: '2017-08-15T21:35:30.321Z'
+    },
+    currentCall2: {
+      id: 2,
+      campaign_id: 1,
+      contact_id: 1,
+      attempt_num: 1,
+      user_id: null,
+      status: 'AVAILABLE',
+      outcome: 'PENDING',
+      notes: null,
+      call_sid: null,
+      call_started: null,
+      call_ended: null,
+      created_at: '2017-08-15T21:35:30.321Z',
+      updated_at: '2017-08-15T21:35:30.321Z'
+    },
+    assignedCall1: {
+      id: 1,
+      campaign_id: 1,
+      contact_id: 1,
+      attempt_num: 1,
+      user_id: 1,
+      status: 'AVAILABLE',
+      outcome: 'PENDING',
+      notes: null,
+      call_sid: null,
+      call_started: null,
+      call_ended: null,
+      created_at: '2017-08-15T21:35:30.321Z',
+      updated_at: '2017-08-15T21:35:30.321Z'
+    }
   }
 };

--- a/test/client/client_fixtures.js
+++ b/test/client/client_fixtures.js
@@ -371,21 +371,6 @@ export default {
       created_at: '2017-08-15T21:35:30.321Z',
       updated_at: '2017-08-15T21:35:30.321Z'
     },
-    currentCall: {
-      id: 2,
-      campaign_id: 1,
-      contact_id: 1,
-      attempt_num: 1,
-      user_id: 1,
-      status: 'AVAILABLE',
-      outcome: 'PENDING',
-      notes: null,
-      call_sid: null,
-      call_started: null,
-      call_ended: null,
-      created_at: '2017-08-15T21:35:30.321Z',
-      updated_at: '2017-08-15T21:35:30.321Z'
-    },
     assignedCall: {
       id: 1,
       campaign_id: 1,

--- a/test/client/client_fixtures.js
+++ b/test/client/client_fixtures.js
@@ -356,7 +356,7 @@ export default {
     }
   },
   callsFixture: {
-    call1: {
+    call: {
       id: 1,
       campaign_id: 1,
       contact_id: 1,
@@ -371,12 +371,12 @@ export default {
       created_at: '2017-08-15T21:35:30.321Z',
       updated_at: '2017-08-15T21:35:30.321Z'
     },
-    currentCall2: {
+    currentCall: {
       id: 2,
       campaign_id: 1,
       contact_id: 1,
       attempt_num: 1,
-      user_id: null,
+      user_id: 1,
       status: 'AVAILABLE',
       outcome: 'PENDING',
       notes: null,
@@ -386,7 +386,7 @@ export default {
       created_at: '2017-08-15T21:35:30.321Z',
       updated_at: '2017-08-15T21:35:30.321Z'
     },
-    assignedCall1: {
+    assignedCall: {
       id: 1,
       campaign_id: 1,
       contact_id: 1,

--- a/test/server/services/user.js
+++ b/test/server/services/user.js
@@ -289,8 +289,6 @@ describe('User service tests', function() {
         call_sid: 'CA1234567890qwertyuiopasdfghjklzxc'
       };
 
-      // this.call_sid = 'CA1234567890qwertyuiopasdfghjklzxc';
-
       usersService.getAllUsers()
         .then((users) => {
           this.userUpdateParams2.id = users.models[0].attributes.id;
@@ -404,19 +402,13 @@ describe('User service tests', function() {
     it('should return a null call_sid for current user', (done) => {
       usersService.getUserById({ id: this.userCallSIDParams.id })
         .then((user) => {
-          console.log('user in call_sid null is: ', user);
           expect(user.attributes.call_sid).to.be.null;
           done();
         }, done);
     });
     it('should update the call_sid for user', (done) => {
-      // const params = {
-      //   id: this.userCallSIDParams.id,
-      //   call_sid: this.call_sid
-      // };
       usersService.updateUserById(this.userCallSIDParams)
         .then((user) => {
-          console.log('user after update call_sid is: ', user);
           expect(user.attributes.call_sid).to.equal(this.userCallSIDParams.call_sid);
           done();
         }, done);
@@ -424,8 +416,6 @@ describe('User service tests', function() {
     it('should not change other attributes by updating the call_sid', (done) => {
       usersService.getUserById({ id: this.userCallSIDParams.id })
         .then((user) => {
-          console.log('user in other attributes ', user);
-          console.log('this.userUpdateParams2 is: ', this.userUpdateParams2);
           expect(user.attributes.call_sid).to.equal(this.userCallSIDParams.call_sid);
           expect(user.attributes.first_name).to.equal(this.userUpdateParams2.firstName);
           expect(user.attributes.last_name).to.equal(this.userUpdateParams2.lastName);
@@ -439,7 +429,6 @@ describe('User service tests', function() {
       };
       usersService.updateUserById(params)
         .then((user) => {
-          console.log('user after clear call_sid is: ', user);
           expect(user.attributes.call_sid).to.be.null;
           done();
         }, done);

--- a/test/server/services/user.js
+++ b/test/server/services/user.js
@@ -395,5 +395,35 @@ describe('User service tests', function() {
           done();
         }, done);
     });
+    it('should return a null call_sid for userManageParams2', (done) => {
+      usersService.getUserById({ id: this.userManageParams2.id })
+        .then((user) => {
+          expect(user.attributes.call_sid).to.be.null;
+          done();
+        }, done);
+    });
+    it('should update the call_sid for userManageParans2', (done) => {
+      const call_sid = 'CA1234567890qwertyuiopasdfghjklzxc';
+      const params = {
+        call_sid,
+        id: this.userManageParams2.id
+      };
+      usersService.updateUserById(params)
+        .then((user) => {
+          expect(user.attributes.call_sid).to.equal(call_sid);
+          done();
+        }, done);
+    });
+    it('should clear the call_sid for userManageParams2', (done) => {
+      const params = {
+        id: this.userManageParams2.id,
+        call_sid: null
+      };
+      usersService.updateUserById(params)
+        .then((user) => {
+          expect(user.attributes.call_sid).to.be.null;
+          done();
+        }, done);
+    });
   });
 });

--- a/test/server/services/user.js
+++ b/test/server/services/user.js
@@ -286,10 +286,17 @@ describe('User service tests', function() {
         isBanned: true
       };
 
+      this.userCallSIDParams = {
+        call_sid: 'CA1234567890qwertyuiopasdfghjklzxc'
+      };
+
+      // this.call_sid = 'CA1234567890qwertyuiopasdfghjklzxc';
+
       usersService.getAllUsers()
         .then((users) => {
           this.userUpdateParams2.id = users.models[0].attributes.id;
           this.userManageParams2.id = users.models[0].attributes.id;
+          this.userCallSIDParams.id = users.models[0].attributes.id;
           this.userUpdateParams1.id = users.models[1].attributes.id;
           this.userManageParams1.id = users.models[1].attributes.id;
           done();
@@ -395,33 +402,55 @@ describe('User service tests', function() {
           done();
         }, done);
     });
-    it('should return a null call_sid for userManageParams2', (done) => {
-      usersService.getUserById({ id: this.userManageParams2.id })
+    it('should return a null call_sid for current user', (done) => {
+      usersService.getUserById({ id: this.userCallSIDParams.id })
         .then((user) => {
+          console.log('user in call_sid null is: ', user);
           expect(user.attributes.call_sid).to.be.null;
           done();
         }, done);
     });
-    it('should update the call_sid for userManageParams2', (done) => {
-      const call_sid = 'CA1234567890qwertyuiopasdfghjklzxc';
-      const params = {
-        call_sid,
-        id: this.userManageParams2.id
-      };
-      usersService.updateUserById(params)
+    it('should update the call_sid for user', (done) => {
+      // const params = {
+      //   id: this.userCallSIDParams.id,
+      //   call_sid: this.call_sid
+      // };
+      usersService.updateUserById(this.userCallSIDParams)
         .then((user) => {
-          expect(user.attributes.call_sid).to.equal(call_sid);
+          console.log('user after update call_sid is: ', user);
+          expect(user.attributes.call_sid).to.equal(this.userCallSIDParams.call_sid);
+          done();
+        }, done);
+    });
+    it('should not change other attributes by updating the call_sid', (done) => {
+      usersService.getUserById({ id: this.userCallSIDParams.id })
+        .then((user) => {
+          console.log('user in other attributes ', user);
+          console.log('this.userUpdateParams2 is: ', this.userUpdateParams2);
+          expect(user.attributes.call_sid).to.equal(this.userCallSIDParams.call_sid);
+          expect(user.attributes.first_name).to.equal(this.userUpdateParams2.firstName);
+          expect(user.attributes.last_name).to.equal(this.userUpdateParams2.lastName);
           done();
         }, done);
     });
     it('should clear the call_sid for userManageParams2', (done) => {
       const params = {
-        id: this.userManageParams2.id,
+        id: this.userCallSIDParams.id,
         call_sid: null
       };
       usersService.updateUserById(params)
         .then((user) => {
+          console.log('user after clear call_sid is: ', user);
           expect(user.attributes.call_sid).to.be.null;
+          done();
+        }, done);
+    });
+    it('should not change other attributes after clearing the call_sid', (done) => {
+      usersService.getUserById({ id: this.userCallSIDParams.id })
+        .then((user) => {
+          expect(user.attributes.call_sid).to.be.null;
+          expect(user.attributes.first_name).to.equal(this.userUpdateParams2.firstName);
+          expect(user.attributes.last_name).to.equal(this.userUpdateParams2.lastName);
           done();
         }, done);
     });

--- a/test/server/services/user.js
+++ b/test/server/services/user.js
@@ -422,7 +422,7 @@ describe('User service tests', function() {
           done();
         }, done);
     });
-    it('should clear the call_sid for userManageParams2', (done) => {
+    it('should clear the call_sid for user', (done) => {
       const params = {
         id: this.userCallSIDParams.id,
         call_sid: null

--- a/test/server/services/user.js
+++ b/test/server/services/user.js
@@ -402,7 +402,7 @@ describe('User service tests', function() {
           done();
         }, done);
     });
-    it('should update the call_sid for userManageParans2', (done) => {
+    it('should update the call_sid for userManageParams2', (done) => {
       const call_sid = 'CA1234567890qwertyuiopasdfghjklzxc';
       const params = {
         call_sid,


### PR DESCRIPTION
Description:
- Modify Users Table to add call_sid field
- Update controllers and routes for /users/:id/campaigns/:campaign_id/calls endpoints
  - POST populates user's call_sid field with a dummy call_sid
  - GET assigns and fetches a call object
  - DELETE clears the user's call_sid field
- Update client action for fetching a call using the GET method
- Add tests to user service for updating the call_sid

Note:
- Using a dummy call_sid for the POST endpoint - this will need to be updated once calls are hooked up

Tests:
- run `npm run test:server`
- check endpoints on postman using `/users/2/campaigns/1/calls`

Jira Ticket 110