### PR TITLE
Add Twilio-related env variables and put all under global setting.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,11 @@ services:
 addons:
   postgresql: "9.6"
 env:
-  - PG_CONNECTION_STRING_TEST="postgres://postgres@localhost:5432/phonebank_test"
+  global:
+    - PG_CONNECTION_STRING_TEST="postgres://postgres@localhost:5432/phonebank_test"
+    - TWILIO_ACCOUNT_SID="AC99999999999999999999999999999999"
+    - TWILIO_AUTH_TOKEN="a9a9a9a9a9a9a9a9a9a9a9a9a9a9a9a9"
+    - TWILIO_CALLER_ID="+15555555555"
 before_script:
   - psql -c 'create database phonebank_test;' -U postgres
 cache:


### PR DESCRIPTION
Added dummy twilio env variables to travis.yml. Now that there are more than one env set in the travis yaml file, they are listed under `env:global:`. Without putting them under global they are tested individually with each one set and the others not used. Putting them under global keeps them in the same environment, and only one test is run with all variables set.