### PR TITLE
[Ticket 140] Sort admin lists

### DIFF
--- a/public/src/actions/admin_contact_lists.jsx
+++ b/public/src/actions/admin_contact_lists.jsx
@@ -24,7 +24,7 @@ export function fetchAllContactLists() {
   return dispatch => axios.get('/contactLists')
     .then((res) => {
       const contactLists = res.data;
-      dispatch(setContactListOptions(contactLists));
+      dispatch(setContactListOptions(contactLists.sort((a, b) => (a.id - b.id))));
       return contactLists;
     })
     .catch((err) => {

--- a/public/src/actions/admin_questions.jsx
+++ b/public/src/actions/admin_questions.jsx
@@ -22,7 +22,7 @@ export function fetchAllQuestions() {
   })
   .then((questions) => {
     const { data: questionsList } = questions;
-    return dispatch(setQuestionList(questionsList));
+    return dispatch(setQuestionList(questionsList.sort((a, b) => (a.id - b.id))));
   })
   .catch((err) => {
     const customError = {

--- a/public/src/actions/admin_scripts.jsx
+++ b/public/src/actions/admin_scripts.jsx
@@ -29,7 +29,7 @@ export function fetchAllScripts() {
   })
   .then((scripts) => {
     const { data: scriptList } = scripts;
-    return dispatch(setScriptsList(scriptList));
+    return dispatch(setScriptsList(scriptList.sort((a, b) => (a.id - b.id))));
   })
   .catch((err) => {
     console.log('error fetching all scripts: ', err);

--- a/public/src/actions/admin_users.jsx
+++ b/public/src/actions/admin_users.jsx
@@ -36,7 +36,7 @@ export function fetchAllUsers(currentUserId) {
       const { id } = object;
       return id !== currentUserId;
     });
-    return dispatch(setUserList(filteredUsersList));
+    return dispatch(setUserList(filteredUsersList.sort((a, b) => (a.id - b.id))));
   })
   .catch(err => console.log('problem fetching all users from db in action "fetchAllUsers"', err));
 }

--- a/public/src/actions/campaign.jsx
+++ b/public/src/actions/campaign.jsx
@@ -69,7 +69,7 @@ export function fetchCampaigns(status = '') {
   })
   .then((campaigns) => {
     const { data: campaignsList } = campaigns;
-    return dispatch(setCampaignsList(campaignsList));
+    return dispatch(setCampaignsList(campaignsList.sort((a, b) => (a.id - b.id))));
   })
   .catch((err) => {
     console.log('error fetching all campaigns from the db: ', err);
@@ -92,10 +92,10 @@ export function fetchCampaignsByUser(userId, current_campaign) {
   .then((campaigns) => {
     const { data: campaignsList } = campaigns;
     if (!current_campaign || Object.getOwnPropertyNames(current_campaign).length === 0) {
-      dispatch(setCampaignsList(campaignsList));
+      dispatch(setCampaignsList(campaignsList.sort((a, b) => (a.id - b.id))));
       return dispatch(setCurrentCampaign(campaignsList[0]));
     }
-    return dispatch(setCampaignsList(campaignsList));
+    return dispatch(setCampaignsList(campaignsList.sort((a, b) => (a.id - b.id))));
   })
   .catch((err) => {
     const customError = {

--- a/test/client/actions/admin_campaigns.test.js
+++ b/test/client/actions/admin_campaigns.test.js
@@ -10,6 +10,7 @@ exposeLocalStorageMock();
 
 const { defaultScripts: initialState,
         listFixture: campaignListFixtures,
+        sortedListFixture: campaignSortedListFixtures,
         mapFixture: campaignFixture } = fixtures.campaignFixtures;
 
 describe('campaign actions', () => {
@@ -89,14 +90,12 @@ describe('campaign actions', () => {
     });
     describe('axios GET request: ', () => {
       it('should add the appropriate action to the store: ', () => {
-        const expectedAction = setCampaignsList(campaignListFixtures);
+        const { type, payload } = setCampaignsList(campaignSortedListFixtures);
         return store.dispatch(fetchCampaigns())
           .then(() => {
-            const [dispatchedActions] = store.getActions();
-            const { type, payload } = dispatchedActions;
-            expect(dispatchedActions).toEqual(expectedAction);
-            expect(type).toBe('SET_CAMPAIGNS');
-            expect(payload).toEqual(campaignListFixtures);
+            const dispatchedActions = store.getActions();
+            expect(dispatchedActions[0].payload).toEqual(payload);
+            expect(dispatchedActions[0].type).toEqual(type);
           });
       });
     });
@@ -114,14 +113,12 @@ describe('campaign actions', () => {
     });
     describe('axios GET request: ', () => {
       it('should add the appropriate action to the store: ', () => {
-        const expectedAction = setCampaignsList(campaignListFixtures);
+        const { type, payload } = setCampaignsList(campaignSortedListFixtures);
         return store.dispatch(fetchCampaignsByUser(1))
           .then(() => {
-            const [dispatchedActions] = store.getActions();
-            const { type, payload } = dispatchedActions;
-            expect(dispatchedActions).toEqual(expectedAction);
-            expect(type).toBe('SET_CAMPAIGNS');
-            expect(payload).toEqual(campaignListFixtures);
+            const dispatchedActions = store.getActions();
+            expect(dispatchedActions[0].type).toEqual(type);
+            expect(dispatchedActions[0].payload).toEqual(payload);
           });
       });
     });

--- a/test/client/actions/admin_contactlist.test.js
+++ b/test/client/actions/admin_contactlist.test.js
@@ -9,7 +9,8 @@ exposeLocalStorageMock();
 
 const { defaultScriptsContactsForm: initialState } = fixtures.campaignFixtures;
 const { listFixture: contactListFixtures,
-        mapFixture: contactListFixture } = fixtures.contactListFixtures;
+        mapFixture: contactListFixture,
+        sortedListFixture: contactListSortedFixtures } = fixtures.contactListFixtures;
 const history = { goBack: jest.fn() };
 const fileList = {
   files: [{
@@ -87,14 +88,12 @@ describe('Add Campaign actions', () => {
     });
     describe('axios GET requests: ', () => {
       it('should add the appropriate action to the store: ', () => {
-        const expectedAction = setContactListOptions(contactListFixtures);
+        const { type, payload } = setContactListOptions(contactListSortedFixtures);
         return store.dispatch(fetchAllContactLists())
           .then(() => {
             const dispatchedActions = store.getActions();
-            const { type, payload } = dispatchedActions[0];
-            expect(dispatchedActions[0]).toEqual(expectedAction);
-            expect(type).toBe('SET_CAMPAIGN_FORM_CONTACT_LIST');
-            expect(payload).toEqual(contactListFixtures);
+            expect(dispatchedActions[0].type).toEqual(type);
+            expect(dispatchedActions[0].payload).toEqual(payload);
           });
       });
     });

--- a/test/client/actions/admin_questions.test.js
+++ b/test/client/actions/admin_questions.test.js
@@ -9,7 +9,8 @@ exposeLocalStorageMock();
 
 const { defaultScripts: initialState,
         listFixture: questionListFixtures,
-        mapFixture: questionFixture } = fixtures.questionFixtures;
+        mapFixture: questionFixture,
+        sortedListFixture: questionSortedListFixture } = fixtures.questionFixtures;
 
 describe('question actions', () => {
   let mock;
@@ -89,15 +90,14 @@ describe('question actions', () => {
     });
     describe('axios GET request: ', () => {
       it('should add the appropriate action to the store: ', () => {
-        const expectedAction = setQuestionList(questionListFixtures);
+        const { type, payload } = setQuestionList(questionSortedListFixture);
         return store.dispatch(fetchAllQuestions())
           .then(() => {
             const dispatchedActions = store.getActions();
-            const { type, payload } = dispatchedActions[0];
-            expect(dispatchedActions[0]).toEqual(expectedAction);
-            expect(type).toBe('SET_QUESTIONS');
-            expect(payload).toEqual(questionListFixtures);
-          });
+            expect(dispatchedActions[0].payload).toEqual(payload);
+            expect(dispatchedActions[0].type).toEqual(type);
+          })
+          .catch(err => console.log('Error in fetchAllQuestions test is: ', err));
       });
     });
   });

--- a/test/client/actions/admin_scripts.test.js
+++ b/test/client/actions/admin_scripts.test.js
@@ -13,7 +13,8 @@ exposeLocalStorageMock();
 
 const { defaultScripts: initialState,
         listFixture: scriptListFixtures,
-        mapFixture: scriptFixture } = fixtures.scriptFixtures;
+        mapFixture: scriptFixture,
+        sortedListFixture: scriptSortedListFixture } = fixtures.scriptFixtures;
 
 const { listFixture: questionListFixtures,
         mapFixture: questionFixture } = fixtures.questionFixtures;
@@ -108,16 +109,13 @@ describe('script actions', () => {
 
     describe('axios GET request: ', () => {
       it('should add the appropriate action to the store: ', () => {
-        const expectedAction = setScriptsList(scriptListFixtures);
+        const { type, payload } = setScriptsList(scriptSortedListFixture);
 
         return store.dispatch(fetchAllScripts())
           .then(() => {
             const dispatchedActions = store.getActions();
-            const { type, payload } = dispatchedActions[0];
-
-            expect(dispatchedActions[0]).toEqual(expectedAction);
-            expect(type).toBe('SET_SCRIPTS');
-            expect(payload).toEqual(scriptListFixtures);
+            expect(dispatchedActions[0].type).toEqual(type);
+            expect(dispatchedActions[0].payload).toEqual(payload);
           });
       });
     });

--- a/test/client/actions/admin_users.test.js
+++ b/test/client/actions/admin_users.test.js
@@ -24,7 +24,8 @@ function parsePayload(payloadObj) {
 const { defaultUsers: initialState,
         listFixture: usersListFixture,
         mapFixture: userFixture,
-        updatedListFixture: usersUpdatedList } = fixtures.usersFixture;
+        updatedListFixture: usersUpdatedList,
+        sortedListFixture: usersSortedListFixture } = fixtures.usersFixture;
 
 describe('admin users list actions tests: ', () => {
   let mock;
@@ -105,7 +106,7 @@ describe('admin users list actions tests: ', () => {
         // test has problem bc of the json stringify method
         const currentUserId = 1;
         const filteredUsersList = usersListFixture.filter(userObj => userObj.id !== currentUserId);
-        const expectedAction = setUserList(filteredUsersList);
+        const expectedAction = setUserList(filteredUsersList.sort((a, b) => (a.id - b.id)));
         return store.dispatch(fetchAllUsersOriginal(currentUserId))
           .then(() => {
             const [dispatchedActions] = store.getActions();

--- a/test/client/client_fixtures.js
+++ b/test/client/client_fixtures.js
@@ -16,6 +16,32 @@ export default {
         updated_at: '2017-08-15T21:35:30.321Z'
       },
       {
+        id: 3,
+        name: 'Script 3',
+        description: 'test script 3',
+        body: 'meow',
+        created_at: '2017-08-15T21:35:30.321Z',
+        updated_at: '2017-08-15T21:35:30.321Z'
+      },
+      {
+        id: 2,
+        name: 'Script 2',
+        description: 'test script 2',
+        body: 'meow',
+        created_at: '2017-08-15T21:35:30.321Z',
+        updated_at: '2017-08-15T21:35:30.321Z'
+      }
+    ],
+    sortedListFixture: [
+      {
+        id: 1,
+        name: 'Script 1',
+        description: 'test script 1',
+        body: 'meow',
+        created_at: '2017-08-15T21:35:30.321Z',
+        updated_at: '2017-08-15T21:35:30.321Z'
+      },
+      {
         id: 2,
         name: 'Script 2',
         description: 'test script 2',
@@ -45,16 +71,7 @@ export default {
     defaultQuestions,
     listFixture: [
       {
-        id: 4,
-        title: 'Question',
-        description: 'test question 1',
-        type: 'singleselect',
-        responses: 'no,yes,who cares,',
-        created_at: '',
-        updated_at: ''
-      },
-      {
-        id: 3,
+        id: 2,
         title: 'Question 2',
         description: 'test question 2',
         type: 'paragraph',
@@ -63,7 +80,54 @@ export default {
         updated_at: ''
       },
       {
+        id: 1,
+        title: 'Question',
+        description: 'test question 1',
+        type: 'singleselect',
+        responses: 'no,yes,who cares,',
+        created_at: '',
+        updated_at: ''
+      },
+      {
+        id: 4,
+        title: 'Question 4',
+        description: 'test question 4',
+        type: 'multiselect',
+        responses: 'meow,meow',
+        created_at: '',
+        updated_at: ''
+      },
+      {
+        id: 3,
+        title: 'Question 3',
+        description: 'test question 3',
+        type: 'multiselect',
+        responses: 'meow,meow2',
+        created_at: '',
+        updated_at: ''
+      }
+    ],
+    sortedListFixture: [
+      {
+        id: 1,
+        title: 'Question',
+        description: 'test question 1',
+        type: 'singleselect',
+        responses: 'no,yes,who cares,',
+        created_at: '',
+        updated_at: ''
+      },
+      {
         id: 2,
+        title: 'Question 2',
+        description: 'test question 2',
+        type: 'paragraph',
+        responses: '',
+        created_at: '',
+        updated_at: ''
+      },
+      {
+        id: 3,
         title: 'Question 3',
         description: 'test question 3',
         type: 'multiselect',
@@ -72,7 +136,7 @@ export default {
         updated_at: ''
       },
       {
-        id: 1,
+        id: 4,
         title: 'Question 4',
         description: 'test question 4',
         type: 'multiselect',
@@ -94,6 +158,41 @@ export default {
   campaignFixtures: {
     defaultCampaigns,
     listFixture: [
+      {
+        id: 1,
+        name: 'Campaign 3',
+        title: 'Campaign 3 Title',
+        description: 'ice cream',
+        status: 'active',
+        contact_lists_id: 1,
+        script_id: 1,
+        updated_at: '4321',
+        created_at: '1234'
+      },
+      {
+        id: 3,
+        name: 'Campaign 3',
+        title: 'Campaign 3 Title',
+        description: 'ice cream',
+        status: 'active',
+        contact_lists_id: 3,
+        script_id: 3,
+        updated_at: '4321',
+        created_at: '1234'
+      },
+      {
+        id: 2,
+        name: 'Campaign 3',
+        title: 'Campaign 3 Title',
+        description: 'ice cream',
+        status: 'active',
+        contact_lists_id: 2,
+        script_id: 2,
+        updated_at: '4321',
+        created_at: '1234'
+      }
+    ],
+    sortedListFixture: [
       {
         id: 1,
         name: 'Campaign 3',
@@ -189,6 +288,26 @@ export default {
         updated_at: '2017-08-15T21:35:30.321Z'
       },
       {
+        id: 3,
+        name: 'ContactList3',
+        created_at: '2017-08-15T21:35:30.321Z',
+        updated_at: '2017-08-15T21:35:30.321Z'
+      },
+      {
+        id: 2,
+        name: 'ContactList2',
+        created_at: '2017-08-15T21:35:30.321Z',
+        updated_at: '2017-08-15T21:35:30.321Z'
+      }
+    ],
+    sortedListFixture: [
+      {
+        id: 1,
+        name: 'ContactList1',
+        created_at: '2017-08-15T21:35:30.321Z',
+        updated_at: '2017-08-15T21:35:30.321Z'
+      },
+      {
         id: 2,
         name: 'ContactList2',
         created_at: '2017-08-15T21:35:30.321Z',
@@ -267,6 +386,44 @@ export default {
       all_users: []
     },
     listFixture: [
+      {
+        id: 2,
+        first_name: 'alyse',
+        last_name: 'oneto',
+        phone_number: '1231231234',
+        email: 'nene@aol.com',
+        is_active: false,
+        is_banned: false,
+        is_admin: false,
+        created_at: '2017-08-24T01:01:01.145Z',
+        updated_at: '2017-08-25T22:01:10.202Z'
+      },
+      {
+        id: 1,
+        first_name: 'andi',
+        last_name: 'oneto',
+        phone_number: '1231231234',
+        email: 'nene@aol.com',
+        is_active: true,
+        is_banned: false,
+        is_admin: true,
+        created_at: '2017-08-24T01:01:01.145Z',
+        updated_at: '2017-08-25T22:01:10.202Z'
+      },
+      {
+        id: 3,
+        first_name: 'william',
+        last_name: 'oneto',
+        phone_number: '1231231234',
+        email: 'nene@aol.com',
+        is_active: false,
+        is_banned: true,
+        is_admin: false,
+        created_at: '2017-08-24T01:01:01.145Z',
+        updated_at: '2017-08-25T22:01:10.202Z'
+      }
+    ],
+    sortedListFixture: [
       {
         id: 1,
         first_name: 'andi',

--- a/test/client/reducers/admin_contact_lists.test.js
+++ b/test/client/reducers/admin_contact_lists.test.js
@@ -39,9 +39,9 @@ describe('adminContactListsReducer tests: ', () => {
       expect(contact_lists.length).toBe(expectedContactListProps.length);
     });
     it('contact_lists name should correspond to mock data', () => {
-      expect(first.name).toBe('ContactList1');
-      expect(second.name).toBe('ContactList2');
-      expect(third.name).toBe('ContactList3');
+      expect(first.name).toBe(contactListFixtures[0].name);
+      expect(second.name).toBe(contactListFixtures[1].name);
+      expect(third.name).toBe(contactListFixtures[2].name);
     });
   });
 


### PR DESCRIPTION
Description:
- Add sort function to the following actions: 
  - fetchCampaigns
  - fetchCampaignsByUser
  - fetchAllUsers
  - fetchAllContactLists
  - fetchAllQuestions
  - fetchAllScripts
- Update tests and client fixtures to reflect sorting

Test:
- run `npm run test:client`