### PR TITLE
Update Hang Up button disable issue

### DIFF
--- a/public/src/components/calls/callcntrl_btn_group.jsx
+++ b/public/src/components/calls/callcntrl_btn_group.jsx
@@ -4,18 +4,19 @@ import { Button, HelpBlock } from 'react-bootstrap';
 const CallControl = (props) => {
   const { handler, text, outcome, status, htmlID, invalid } = props;
   const style = text === 'Hang Up' ? 'danger' : 'success';
-  const disableStatus = (text === 'Hang Up') ? (outcome === 'PENDING' || status !== 'IN_PROGRESS') : ((outcome === 'PENDING' && status !== 'HUNG_UP') || (outcome === 'ANSWERED' && status !== 'HUNG_UP') || invalid);
+  const disableStatus = (text === 'Hang Up') ? (status !== 'IN_PROGRESS') : (outcome === 'PENDING' || (outcome === 'ANSWERED' && status !== 'HUNG_UP') || invalid);
 
   return (
     <div id={htmlID}>
       { invalid && <HelpBlock>Complete survey responses before submit</HelpBlock> }
-      { text !== 'Hang Up' && outcome === 'ANSWERED' && !invalid && status !== 'HUNG_UP' && <HelpBlock> Hang up call before submit</HelpBlock> }
+      { text !== 'Hang Up' && !invalid && status !== 'HUNG_UP' && <HelpBlock> Hang up call before submit</HelpBlock> }
       <Button
         disabled={disableStatus}
         onClick={handler}
         bsStyle={style}
       >
-        {text === 'Hang Up' ? (<i className="material-icons md-16">call end</i>) : (<i className="material-icons md-18">skip_next</i>) }{text}
+        {text === 'Hang Up' ? (<i className="material-icons md-16">call end</i>) : (<i className="material-icons md-18">skip_next</i>) }
+        {(text === 'Hang Up' && status === 'HUNG_UP') ? 'Call Ended' : text}
       </Button>
     </div>
   );


### PR DESCRIPTION
## Description

- Hang up button now is enabled if outcome is not selected
- Once call is hung up, button text changes to "Call Ended"

### test
Go to Active call page and see enabled Hang Up button