### PR TITLE
Make call assignment service return existing assigned calls first

### DIFF
--- a/server/db/services/calls.js
+++ b/server/db/services/calls.js
@@ -5,19 +5,27 @@ export default {
     const { user_id, campaign_id } = params;
 
     return new Call()
-      .where({ campaign_id, status: 'AVAILABLE' })
-      .orderBy('id', 'ASC')
+      .where({ campaign_id, user_id, status: 'ASSIGNED' })
       .fetch()
-      .then((call) => {
-        if (call) {
-          return call.save({ user_id, status: 'ASSIGNED' }, { patch: true })
-            .then(savedCall => savedCall)
-            .catch(err => console.log('Error in call service when assigning to user: ', err));
-        }
+      .then((previousCall) => {
+        if (!previousCall) {
+          return new Call()
+            .where({ campaign_id, status: 'AVAILABLE' })
+            .orderBy('id', 'ASC')
+            .fetch()
+            .then((call) => {
+              if (call) {
+                return call.save({ user_id, status: 'ASSIGNED' }, { patch: true })
+                  .then(savedCall => savedCall)
+                  .catch(err => console.log('Error in call service when assigning to user: ', err));
+              }
 
-        return null;
-      })
-      .catch(err => console.log('Error in call service when finding call to assign:', err));
+              return null;
+            })
+            .catch(err => console.log('Error in call service when finding call to assign:', err));
+        }
+        return previousCall;
+      });
   },
 
   createNewAttempt: (params) => {

--- a/server/db/services/calls.js
+++ b/server/db/services/calls.js
@@ -19,7 +19,6 @@ export default {
                   .then(savedCall => savedCall)
                   .catch(err => console.log('Error in call service when assigning to user: ', err));
               }
-
               return null;
             })
             .catch(err => console.log('Error in call service when finding call to assign:', err));

--- a/test/server/services/calls.js
+++ b/test/server/services/calls.js
@@ -102,10 +102,22 @@ describe('Calls Service tests', function() {
 
       callsService.assignCall({ user_id, campaign_id })
         .then((call) => {
+          this.firstAssignedCall = call.attributes;
+
           expect(call.attributes.user_id).to.equal(this.callSaveParams.user_id);
           expect(call.attributes.status).to.equal('ASSIGNED');
           done();
         }, done);
+    });
+
+    it('should return a previously assigned call if one exists', (done) => {
+      const { user_id, campaign_id } = this.callSaveParams;
+
+      callsService.assignCall({ user_id, campaign_id })
+        .then((call) => {
+          expect(call.attributes).to.deep.equal(this.firstAssignedCall);
+          done();
+        }, done)
     });
   });
 


### PR DESCRIPTION
Previously, the call assignment service could be queried with a user_id and a campaign_id, and would assign an available call to that user repeatedly, until there were no more available.

This pull request makes the service first check to see if there are any calls with the status `'ASSIGNED'` and that user's `id` as the `user_id`, and if so, returns one of those instead of assigning  another call.

There is a service test included that makes the test save the attributes of the first time we assign a call and then it immediately asks for another call for the user and Id and compares the attributes of that call to the saved attributes to make sure that it is indeed the same call.