### PR TITLE
Call duration recorded in callback

### DIFF
--- a/public/src/reducers/calls.jsx
+++ b/public/src/reducers/calls.jsx
@@ -6,8 +6,6 @@ const defaultCalls = {
   contact_id: null,
   status: undefined,
   outcome: undefined,
-  call_ended: null,
-  call_started: null,
   notes: null,
   current_call_contact_name: undefined,
   call_volunteer_active: false
@@ -19,8 +17,6 @@ const clearCallDefault = {
   contact_id: null,
   status: undefined,
   outcome: undefined,
-  call_ended: null,
-  call_started: null,
   notes: null,
   current_call_contact_name: undefined,
   call_volunteer_active: false
@@ -47,8 +43,6 @@ export function volunteerCallsReducer(state = defaultCalls, action) {
         contact_id: payload.contact_id,
         status: payload.status,
         outcome: payload.outcome,
-        call_ended: payload.call_ended,
-        call_started: payload.call_started,
         notes: payload.notes
       };
     case CLEAR_CALL_CURRENT:

--- a/server/controllers/users.js
+++ b/server/controllers/users.js
@@ -280,8 +280,8 @@ export function volunteerCallback(req, res) {
 
 export function contactCallback(req, res) {
   const { call_id: id } = req.params;
-  const { DialCallSid: call_sid } = req.body;
-  return callsService.updateContactCallSid({ id, call_sid })
+  const { DialCallSid: call_sid, DialCallDuration: duration } = req.body;
+  return callsService.updateContactCall({ id, call_sid, duration })
     .then((call) => {
       if (call) {
         res.status(201).json(call);

--- a/server/db/db.js
+++ b/server/db/db.js
@@ -159,8 +159,7 @@ const createCallsTable = () =>
         table.enu('outcome', ['PENDING', 'ANSWERED', 'BAD_NUMBER', 'DO_NOT_CALL', 'LEFT_MSG', 'NO_ANSWER', 'INCOMPLETE']).defaultTo('PENDING').notNullable();
         table.string('notes');
         table.string('call_sid', 34);
-        table.timestamp('call_started');
-        table.timestamp('call_ended');
+        table.integer('duration');
         table.timestamp('created_at').defaultTo(bookshelf.knex.fn.now());
         table.timestamp('updated_at').defaultTo(bookshelf.knex.fn.now());
       });

--- a/server/db/services/calls.js
+++ b/server/db/services/calls.js
@@ -64,7 +64,8 @@ export default {
   },
 
   updateContactCall: (params) => {
-    const { id, call_sid, duration } = params;
+    const { id, call_sid } = params;
+    const duration = parseInt(params.duration, 10);
     return new Call({ id })
       .save({ call_sid, duration }, { patch: true })
       .then(call => call)

--- a/server/db/services/calls.js
+++ b/server/db/services/calls.js
@@ -63,10 +63,10 @@ export default {
       .catch(err => console.log('error in calls service when releasing call: ', err));
   },
 
-  updateContactCallSid: (params) => {
-    const { id, call_sid } = params;
+  updateContactCall: (params) => {
+    const { id, call_sid, duration } = params;
     return new Call({ id })
-      .save({ call_sid }, { patch: true })
+      .save({ call_sid, duration }, { patch: true })
       .then(call => call)
       .catch(err => err);
   }

--- a/test/client/client_fixtures.js
+++ b/test/client/client_fixtures.js
@@ -363,8 +363,6 @@ export default {
       user_id: 1,
       outcome: 'PENDING',
       status: 'ASSIGNED',
-      call_started: null,
-      call_ended: null,
       attempt_num: 1,
       notes: null,
       call_sid: null,
@@ -379,8 +377,6 @@ export default {
       contact_id: null,
       status: undefined,
       outcome: undefined,
-      call_ended: null,
-      call_started: null,
       notes: null,
       current_call_contact_name: undefined,
       call_volunteer_active: false

--- a/test/client/reducers/calls.test.js
+++ b/test/client/reducers/calls.test.js
@@ -52,8 +52,6 @@ describe('volunteerCallsReducer tests: ', () => {
             contact_id,
             status,
             outcome,
-            call_ended,
-            call_started,
             notes,
             current_call_contact_name } = defaultState;
     it('should return the default state if the action type does not match any cases: ', () => {
@@ -73,12 +71,6 @@ describe('volunteerCallsReducer tests: ', () => {
     });
     it('should have a property named contact_id which is null: ', () => {
       expect(typeof contact_id === 'object' && contact_id === null).toBe(true);
-    });
-    it('should have a property named call_ended which is null: ', () => {
-      expect(typeof call_ended === 'object' && call_ended === null).toBe(true);
-    });
-    it('should have a property named call_started which is null: ', () => {
-      expect(typeof call_started === 'object' && call_started === null).toBe(true);
     });
     it('should have a property named notes which is null: ', () => {
       expect(typeof notes === 'object' && notes === null).toBe(true);
@@ -137,8 +129,6 @@ describe('volunteerCallsReducer tests: ', () => {
         contact_id: null,
         status: undefined,
         outcome: undefined,
-        call_ended: null,
-        call_started: null,
         notes: null
       };
       it('should return default state to the correct props: ', () => {

--- a/test/server/services/calls.js
+++ b/test/server/services/calls.js
@@ -48,7 +48,7 @@ describe('Calls Service tests', function() {
 
     this.callSaveParams = {};
 
-    this.callUpdateParams = { call_sid: 'CA1a2b3c4aftd152e566f77g8hi48r9403' };
+    this.callUpdateParams = { call_sid: 'CA1a2b3c4aftd152e566f77g8hi48r9403', duration: '14' };
 
     scriptsService.saveNewScript(this.scriptParams)
       .then((script) => {
@@ -86,11 +86,12 @@ describe('Calls Service tests', function() {
   });
 
   describe('Call update', () => {
-    it('should correctly update call Sid', (done) => {
-      callsService.updateContactCallSid(this.callUpdateParams)
+    it('should correctly update call information', (done) => {
+      callsService.updateContactCall(this.callUpdateParams)
         .then((call) => {
           expect(call.attributes.id).to.equal(this.callUpdateParams.id);
           expect(call.attributes.call_sid).to.equal(this.callUpdateParams.call_sid);
+          expect(call.attributes.duration).to.equal(parseInt(this.callUpdateParams.duration, 10));
           done();
         }, done);
     });
@@ -145,8 +146,7 @@ describe('Calls Service tests', function() {
           expect(propList.includes('outcome')).to.equal(true);
           expect(propList.includes('notes')).to.equal(true);
           expect(propList.includes('call_sid')).to.equal(true);
-          expect(propList.includes('call_started')).to.equal(true);
-          expect(propList.includes('call_ended')).to.equal(true);
+          expect(propList.includes('duration')).to.equal(true);
           done();
         }, done);
     });


### PR DESCRIPTION
# Description
- With the data received from Twilio in the callback (`users/:id/campaigns/:campaign_id/calls/:call_id/callback`), the call duration is now saved in the call object.
- Database is updated --> call end and start is replaced with 'duration'

# Test 
- Go to /services/calls into the updateContactCallback service to see the changes (name was made more general since it is now updating the SID + duration)
- Run updated tests (`npm run test:server`)
- Start calling a campaign on the client to see duration recorded after each call