### PR TITLE
Link stats page on campaign list view

### DIFF
--- a/public/src/components/common/button_objs.jsx
+++ b/public/src/components/common/button_objs.jsx
@@ -25,7 +25,9 @@ export default {
       }
     ];
   },
-  admin_campaigns() { // deleted props and item as arguments because they were causing an error
+  admin_campaigns(props) { // deleted props and item as arguments because they were causing an error
+    const { page, item, history } = props;
+    const { id } = item;
     return [
       {
         key: 1,
@@ -36,10 +38,12 @@ export default {
       },
       {
         key: 2,
-        text: () => 'Call Report',
+        text: () => 'Campaign Stats',
         size: 'xsmall',
         style: 'success',
-        handler: () => {}
+        handler: () => {
+          history.push(`/admin/${page.toLowerCase()}s/${id}`);
+        }
       },
       {
         key: 3,


### PR DESCRIPTION
## Description
Link stats button to '/campaigns/:id' where stats view will be.

## Test
1. Log in as admin
2. View all campaigns and see the button
3. Click the button, page doesn't exist yet but is being pushed to that path.