### PR TITLE
Fix left message bug

### DIFF
--- a/public/src/components/calls/active_call_control.jsx
+++ b/public/src/components/calls/active_call_control.jsx
@@ -75,7 +75,7 @@ export default class ActiveCallControl extends Component {
         icon: 'call_missed'
       },
       {
-        value: 'LEFT_MESSAGE',
+        value: 'LEFT_MSG',
         label: 'Left Message',
         styled: 'warning',
         icon: 'mic'


### PR DESCRIPTION
## Description
Bug with "Left Message" button fixed

## Test
During an active call, you can now set outcome to "Left Message"
