### PR TITLE
Ticket 155: Remove status is ATTEMPTED logic from calls action updateCallAttempt

### DIFF
--- a/public/src/actions/calls.jsx
+++ b/public/src/actions/calls.jsx
@@ -155,7 +155,7 @@ export function releaseCall(userId, campaignId, callId, currentCallStatus) {
   .catch(err => err);
 }
 
-export function updateCallAttempt(callUpdateParams, assignCall = assignToCall) {
+export function updateCallAttempt(callUpdateParams) {
   const { user_id: userId,
           campaign_id: campaignId,
           call_id: callId,
@@ -169,12 +169,7 @@ export function updateCallAttempt(callUpdateParams, assignCall = assignToCall) {
       headers: { Authorization: ` JWT ${localStorage.getItem('auth_token')}` }
     }
   )
-  .then(() => {
-    if (status === 'ATTEMPTED') {
-      return dispatch(assignCall(userId, campaignId));
-    }
-    return dispatch(updateCallStatus(status));
-  })
+  .then(() => dispatch(updateCallStatus(status)))
   .catch(err => console.log(err));
 }
 

--- a/test/client/actions/calls.test.js
+++ b/test/client/actions/calls.test.js
@@ -309,7 +309,6 @@ describe('Call Actions', () => {
     afterEach(() => {
       mock.reset();
     });
-    // TODO: when form submission is finished, finish case for when call status is marked ATTEMPTED
     describe('aixios put request when call status is not ATTEMPTED: ', () => {
       it('should dispatch UPDATE_CALL_STATUS: ', () => {
         const expectedAction = updateCallStatus('in_progress');


### PR DESCRIPTION
**Removed logic to handle statuses that are ATTEMPTED, as this is no longer handled by this action.

**Revised code:
```
export function updateCallAttempt(callUpdateParams) {
  const { user_id: userId,
          campaign_id: campaignId,
          call_id: callId,
          status,
          outcome,
          notes } = callUpdateParams;
  const params = { status, outcome, notes };
  return dispatch => axios.put(`/users/${userId}/campaigns/${campaignId}/calls/${callId}`,
    params,
    {
      headers: { Authorization: ` JWT ${localStorage.getItem('auth_token')}` }
    }
  )
  .then(() => dispatch(updateCallStatus(status)))
  .catch(err => console.log(err));
}

```