### PR TITLE
fetchCampaigns admin campaign list fix

### DIFF
--- a/public/src/components/campaign/campaign_list.jsx
+++ b/public/src/components/campaign/campaign_list.jsx
@@ -13,7 +13,10 @@ export default class CampaignList extends Component {
     this.volunteerJoinCampaignClick = this.volunteerJoinCampaignClick.bind(this);
   }
   componentDidMount() {
-    const { is_admin: isAdmin } = this.props.account_info;
+    // Note: this was a fix for the demo, this should be added
+    // to list of things to carry over
+    // const { is_admin: isAdmin } = this.props.account_info;
+    const isAdmin = localStorage.getItem('permissions');
     const status = isAdmin ? '' : 'active';
     this.props.fetchCampaigns(status);
   }

--- a/test/client/components/common/campaign_quest_script_list.test.js
+++ b/test/client/components/common/campaign_quest_script_list.test.js
@@ -8,7 +8,9 @@ import ContactLists from '../../../../public/src/components/contactlist/contactl
 import UsersList from '../../../../public/src/components/users/users_list';
 
 import fixtures from '../../client_fixtures';
-import { checkObjectProps } from '../../client_test_helpers';
+import { checkObjectProps, exposeLocalStorageMock } from '../../client_test_helpers';
+
+exposeLocalStorageMock();
 
 const { listFixture: campaignListFixtures } = fixtures.campaignFixtures;
 const { listFixture: questionListFixtures } = fixtures.questionFixtures;


### PR DESCRIPTION
bug where the action was only fetching active campaigns
occurs bc the state is not accessible when the componentDidMount is invoked => is_admin === null, which is falsey => status was being set to active
This looks at the localStorage prop that stores is_admin equivalent, that is used for subapp separation

TODO: as with all other "session" info in localStorage this will need to be reconfigured. But for now, it's fine.